### PR TITLE
mbedtls: Kconfig: Re-organize to enabled choosing an mbedtls impl.

### DIFF
--- a/ext/lib/crypto/mbedtls/Kconfig
+++ b/ext/lib/crypto/mbedtls/Kconfig
@@ -20,17 +20,27 @@
 menuconfig MBEDTLS
 	bool
 	prompt "mbedTLS Support"
-	select MBEDTLS_BUILTIN
 	default n
 	help
 	  This option enables the mbedTLS cryptography library.
 
+if MBEDTLS
+
+choice
+	prompt "Select implementation"
+	default MBEDTLS_BUILTIN
+
 config MBEDTLS_BUILTIN
 	bool "Enable mbedTLS integrated sources"
-	depends on MBEDTLS
-	default n
 	help
 	Link with local mbedTLS sources instead of external library.
+
+config MBEDTLS_LIBRARY
+	bool "Enable mbedTLS external library"
+	help
+	This option enables mbedTLS library.
+
+endchoice
 
 config MBEDTLS_CFG_FILE
 	string "mbed TLS configuration file"
@@ -60,13 +70,6 @@ config MBEDTLS_TEST
 	help
 	Enable self test function for the crypto algorithms
 
-config MBEDTLS_LIBRARY
-	bool "Enable mbedTLS external library"
-	depends on MBEDTLS
-	default n
-	help
-	This option enables mbedTLS library.
-
 config MBEDTLS_INSTALL_PATH
 	string "mbedTLS install path"
 	depends on MBEDTLS_LIBRARY
@@ -78,7 +81,6 @@ config MBEDTLS_INSTALL_PATH
 config MBEDTLS_ENABLE_HEAP
 	bool "Enable global heap for mbed TLS"
 	default n
-	depends on MBEDTLS
 	help
 	This option enables the mbedtls to use the heap. This setting must
 	be global so that various applications and libraries in Zephyr do not
@@ -99,3 +101,5 @@ config MBEDTLS_HEAP_SIZE
 	application. For server application 15000 bytes should be enough.
 	For some dedicated and specific usage of mbedtls API, the 1000 bytes
 	might be ok.
+
+endif


### PR DESCRIPTION
CONFIG_MBEDTLS means you are using MBEDTLS
CONFIG_MBEDTLS_BUILTIN means you are using a built-in MDEDTLS
CONFIG_MBEDTLS_LIBRARY means you are using an external MBEDTLS

This patch ensures that you must select one or the other
implementation when MBEDTLS is enabled.

Tested by opening xconfig and observing that when MBEDTLS was enabled,
BUILTIN was automatically enabled, and a radio-button interface
existed to change the implementation.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>